### PR TITLE
#LogCrashSearch-개발/2982 - SDK Unity 관련 링크 제거

### DIFF
--- a/en/sdk-guide-toast-L&C.md
+++ b/en/sdk-guide-toast-L&C.md
@@ -14,9 +14,6 @@ With NHN Cloud Log & Crash Search SDK, easy and strong remote log and crash anal
 #### Android
 * See [Guide for NHN Cloud Log & Crash Search Android](https://docs.toast.com/ko/TOAST/ko/toast-sdk/log-collector-android/).
 
-#### Unity
-* See [Guide for NHN Cloud Log & Crash Search Unity](https://docs.toast.com/ko/TOAST/ko/toast-sdk/log-collector-unity/).
-
 #### Windows C++
 * See [Guide for NHN Cloud Log & Crash Search Windows C++](https://docs.toast.com/ko/TOAST/ko/toast-sdk/log-collector-windows/).
 

--- a/ja/sdk-guide-toast-L&C.md
+++ b/ja/sdk-guide-toast-L&C.md
@@ -14,9 +14,6 @@ NHN Cloud Log & Crash Search SDKを適用すると、モバイルアプリケー
 #### Android
 * [NHN Cloud Log & Crash Search Androidガイド](https://docs.toast.com/ko/TOAST/ko/toast-sdk/log-collector-android/)を参照してください。
 
-#### Unity
-* [NHN Cloud Log & Crash Search Unityガイド](https://docs.toast.com/ko/TOAST/ko/toast-sdk/log-collector-unity/)を参照してください。
-
 #### Windows C++
 * [NHN Cloud Log & Crash Search Windows C++ ガイド](https://docs.toast.com/ko/TOAST/ko/toast-sdk/log-collector-windows/)を参照してください。
 

--- a/zh/sdk-guide-toast-L&C.md
+++ b/zh/sdk-guide-toast-L&C.md
@@ -14,9 +14,6 @@ With NHN Cloud Log & Crash Search SDK, easy and strong remote log and crash anal
 #### Android
 * See [Guide for NHN Cloud Log & Crash Search Android](https://docs.toast.com/ko/TOAST/ko/toast-sdk/log-collector-android/).
 
-#### Unity
-* See [Guide for NHN Cloud Log & Crash Search Unity](https://docs.toast.com/ko/TOAST/ko/toast-sdk/log-collector-unity/).
-
 #### Windows C++
 * See [Guide for NHN Cloud Log & Crash Search Windows C++](https://docs.toast.com/ko/TOAST/ko/toast-sdk/log-collector-windows/).
 


### PR DESCRIPTION
- JP, EN, ZH의 관련 링크 제거